### PR TITLE
Add libcap to rpath for native Linux binary

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -8,6 +8,7 @@
 , gnutar
 , gzip
 , openssl
+, libcap
 , runtime ? "native"
 , nativeBinName ? "codex"
 , nodeBinName ? "codex-node"
@@ -51,7 +52,7 @@ let
   runtimeConfig = {
     native = {
       nativeBuildInputs = [ gnutar gzip ] ++ lib.optionals stdenv.isLinux [ patchelf ];
-      buildInputs = lib.optionals stdenv.isLinux [ openssl ];
+      buildInputs = lib.optionals stdenv.isLinux [ openssl libcap ];
       description = "OpenAI Codex CLI (Native Binary) - AI coding assistant in your terminal";
       binName = nativeBinName;
     };
@@ -90,7 +91,7 @@ stdenv.mkDerivation rec {
     ${lib.optionalString stdenv.isLinux ''
     patchelf \
       --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
-      --set-rpath "${lib.makeLibraryPath [ openssl ]}" \
+      --set-rpath "${lib.makeLibraryPath [ openssl libcap ]}" \
       build/codex
     ''}
 


### PR DESCRIPTION
## Summary
- The codex 0.98.0 native binary links against `libcap.so.2` (for Linux sandbox capabilities), but it was not included in the `patchelf --set-rpath` call
- This caused a runtime error: `error while loading shared libraries: libcap.so.2: cannot open shared object file: No such file or directory`
- Added `libcap` to the function inputs, `buildInputs`, and `patchelf --set-rpath`

## Test plan
- [x] Built with `nix build .#codex` — succeeds
- [x] Verified `ldd result/bin/codex-raw` — `libcap.so.2` now resolves
- [x] Verified `codex --version` — prints `codex-cli 0.98.0` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)