### PR TITLE
fix: add bubblewrap to Linux runtime wrapper

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -3,13 +3,14 @@
 , fetchurl
 , nodejs_22
 , cacert
-, bash
+, makeWrapper
 , patchelf
 , gnutar
 , gzip
 , openssl
 , libcap
 , libz
+, bubblewrap
 , runtime ? "native"
 , nativeBinName ? "codex"
 , nodeBinName ? "codex-node"
@@ -74,13 +75,13 @@ let
 
   runtimeConfig = {
     native = {
-      nativeBuildInputs = [ gnutar gzip ] ++ lib.optionals stdenv.isLinux [ patchelf ];
+      nativeBuildInputs = [ gnutar gzip makeWrapper ] ++ lib.optionals stdenv.isLinux [ patchelf ];
       buildInputs = lib.optionals stdenv.isLinux [ openssl libcap libz ];
       description = "OpenAI Codex CLI (Native Binary) - AI coding assistant in your terminal";
       binName = nativeBinName;
     };
     node = {
-      nativeBuildInputs = [ nodejs_22 cacert ];
+      nativeBuildInputs = [ nodejs_22 cacert makeWrapper ];
       buildInputs = [];
       description = "OpenAI Codex CLI (Node.js) - AI coding assistant in your terminal";
       binName = nodeBinName;
@@ -88,6 +89,7 @@ let
   };
 
   selected = runtimeConfig.${runtime};
+  linuxRuntimePath = lib.makeBinPath (lib.optionals stdenv.isLinux [ bubblewrap ]);
 in
 assert runtime == "native" -> platform != null ||
   throw "Native runtime not supported on ${stdenv.hostPlatform.system}. Supported: aarch64-darwin, x86_64-darwin, x86_64-linux, aarch64-linux";
@@ -145,34 +147,22 @@ stdenv.mkDerivation rec {
 
     cp build/codex $out/bin/codex-raw
     chmod +x $out/bin/codex-raw
-
-    cat > $out/bin/${selected.binName} << 'WRAPPER_EOF'
-#!${bash}/bin/bash
-export CODEX_EXECUTABLE_PATH="$HOME/.local/bin/${selected.binName}"
-export DISABLE_AUTOUPDATER=1
-exec "$out/bin/codex-raw" "$@"
-WRAPPER_EOF
-    chmod +x $out/bin/${selected.binName}
-
-    substituteInPlace $out/bin/${selected.binName} \
-      --replace-fail '$out' "$out"
+    makeWrapper "$out/bin/codex-raw" "$out/bin/${selected.binName}" \
+      --set CODEX_EXECUTABLE_PATH '$HOME/.local/bin/${selected.binName}' \
+      --set DISABLE_AUTOUPDATER 1 \
+      ${lib.optionalString stdenv.isLinux ''--prefix PATH : "${linuxRuntimePath}"''}
     runHook postInstall
   '' else ''
     runHook preInstall
     mkdir -p $out/bin
 
-    cat > $out/bin/${selected.binName} << 'WRAPPER_EOF'
-#!${bash}/bin/bash
-export NODE_PATH="$out/lib/node_modules"
-export CODEX_EXECUTABLE_PATH="$HOME/.local/bin/${selected.binName}"
-export DISABLE_AUTOUPDATER=1
-
-exec ${nodejs_22}/bin/node --no-warnings "$out/lib/node_modules/@openai/codex/bin/codex.js" "$@"
-WRAPPER_EOF
-    chmod +x $out/bin/${selected.binName}
-
-    substituteInPlace $out/bin/${selected.binName} \
-      --replace-fail '$out' "$out"
+    makeWrapper ${nodejs_22}/bin/node "$out/bin/${selected.binName}" \
+      --add-flags --no-warnings \
+      --add-flags "$out/lib/node_modules/@openai/codex/bin/codex.js" \
+      --set NODE_PATH "$out/lib/node_modules" \
+      --set CODEX_EXECUTABLE_PATH '$HOME/.local/bin/${selected.binName}' \
+      --set DISABLE_AUTOUPDATER 1 \
+      ${lib.optionalString stdenv.isLinux ''--prefix PATH : "${linuxRuntimePath}"''}
     runHook postInstall
   '';
 


### PR DESCRIPTION
## Summary

Fixes #82 by making `bubblewrap` available on `PATH` in the packaged Linux runtime environment.

Recent Codex releases no longer rely on a hard-coded `/usr/bin/bwrap`, but they still expect `bubblewrap` to be discoverable on `PATH`. In `codex-cli-nix`, the packaged wrappers did not expose `bubblewrap`, which caused the warning described in the issue.

This follows the same general approach used by `nixpkgs`, which wraps `codex` and prefixes `PATH` with `bubblewrap` on Linux.

## Changes

- add `bubblewrap` as a Linux runtime dependency
- prefix `PATH` with the Nix-provided `bubblewrap` binary for both packaged entrypoints:
  - `codex` (native)
  - `codex-node`
- switch the package wrappers to `makeWrapper` instead of handwritten shell wrappers

## Notes

The visible diff is a bit larger than the functional change because the wrapper implementation was normalized to use `makeWrapper`, but the actual behavior change is only the Linux `PATH` update for `bubblewrap`.

## Validation

- `nix build .#codex`
- `nix build .#codex-node`

Both builds succeed locally, and the generated wrappers include the `bubblewrap` path on Linux.

## References

- fixes #82
- related upstream fix: `openai/codex#15973`
- similar packaging approach in `nixpkgs`: `pkgs/by-name/co/codex/package.nix`
