### PR TITLE
feat: install codex shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Two package variants are available:
 
 - **Native Rust Binary**: Self-contained binary with no runtime dependencies (default)
 - **Node.js Alternative**: Optional Node.js runtime for compatibility
+- **Shell Completions**: Bash, Fish, and Zsh completions included with the default native package
 - **Version Pinning**: Ensures consistent behavior across different environments
 - **Auto-update Protection**: Prevents unexpected updates that might break your workflow
 - **Cross-platform Support**: Pre-built binaries for Linux and macOS (x86_64 and ARM64)

--- a/package.nix
+++ b/package.nix
@@ -5,6 +5,7 @@
 , cacert
 , makeWrapper
 , installShellFiles
+, installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
 , gnutar
 , gzip
 , openssl
@@ -107,6 +108,10 @@ let
 
   selected = runtimeConfig.${runtime};
   linuxRuntimePath = lib.makeBinPath (lib.optionals stdenv.isLinux [ bubblewrap ]);
+  generateShellCompletions =
+    installShellCompletions
+    && runtime == "native"
+    && selected.binName == "codex";
 in
 assert runtime == "native" -> platform != null ||
   throw "Native runtime not supported on ${stdenv.hostPlatform.system}. Supported: aarch64-darwin, x86_64-darwin, x86_64-linux, aarch64-linux";
@@ -121,7 +126,7 @@ stdenv.mkDerivation rec {
   dontStrip = runtime == "native";
 
   nativeBuildInputs = selected.nativeBuildInputs
-    ++ lib.optionals (selected.binName == "codex") [ installShellFiles ];
+    ++ lib.optionals generateShellCompletions [ installShellFiles ];
   buildInputs = selected.buildInputs;
 
   buildPhase = if runtime == "native" then ''
@@ -183,7 +188,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  postInstall = lib.optionalString (selected.binName == "codex") ''
+  postInstall = lib.optionalString generateShellCompletions ''
     installShellCompletion --cmd codex \
       --bash <("$out/bin/${selected.binName}" completion bash) \
       --fish <("$out/bin/${selected.binName}" completion fish) \

--- a/package.nix
+++ b/package.nix
@@ -4,6 +4,7 @@
 , nodejs_22
 , cacert
 , makeWrapper
+, installShellFiles
 , gnutar
 , gzip
 , openssl
@@ -119,7 +120,8 @@ stdenv.mkDerivation rec {
   dontPatchELF = runtime == "native";
   dontStrip = runtime == "native";
 
-  nativeBuildInputs = selected.nativeBuildInputs;
+  nativeBuildInputs = selected.nativeBuildInputs
+    ++ lib.optionals (selected.binName == "codex") [ installShellFiles ];
   buildInputs = selected.buildInputs;
 
   buildPhase = if runtime == "native" then ''
@@ -179,6 +181,13 @@ stdenv.mkDerivation rec {
       --set DISABLE_AUTOUPDATER 1 \
       ${lib.optionalString stdenv.isLinux ''--prefix PATH : "${linuxRuntimePath}"''}
     runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (selected.binName == "codex") ''
+    installShellCompletion --cmd codex \
+      --bash <("$out/bin/${selected.binName}" completion bash) \
+      --fish <("$out/bin/${selected.binName}" completion fish) \
+      --zsh <("$out/bin/${selected.binName}" completion zsh)
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Summary
- Generate and install bash, fish, and zsh completions for the default codex command
- Adds `installShellFiles` as a native build dependency
- Uses `installShellCompletion` to register completions for bash, fish, and zsh

## Test
- `nix build .#codex --no-link`