### PR TITLE
native: fetch and install codex-code-mode-host

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Verify package contents
         run: |
           test -f ./result/bin/codex
+          test -x ./result/bin/codex-code-mode-host
 
       - name: Run basic functionality test
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -80,8 +80,8 @@ jobs:
 
           ### Changes
           - Updated `version` in `package.nix`
-          - Updated native binary hashes for all platforms
-          - Updated npm tarball hash
+          - Updated native codex and code-mode host hashes for all platforms
+          - Updated npm tarball and node platform dependency hashes
 
           ### Checklist
           - [ ] Build passes

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Add to your Home Manager configuration:
 Two package variants are available:
 
 **`codex` (default, native binary)**
-- Pre-built Rust binary from OpenAI's GitHub releases
+- Pre-built Rust CLI and required companion executable from OpenAI's GitHub releases
 - Self-contained, no runtime dependencies
 - Fastest startup time
 - Supported platforms: `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`
@@ -190,7 +190,7 @@ nix develop
 This repository uses GitHub Actions to automatically check for new Codex versions hourly. When a new version is detected:
 
 1. A pull request is automatically created with the version update
-2. The tarball hash is automatically calculated
+2. Required release artifact hashes are automatically refreshed
 3. Tests run on both Linux and macOS to verify the build
 4. The PR auto-merges if all checks pass
 

--- a/package.nix
+++ b/package.nix
@@ -43,13 +43,13 @@ let
   };
 
   # codex >= 0.143 spawns a separate `codex-code-mode-host` binary (found
-  # next to the main executable) when "code mode" is enabled. Shipped as its
+  # next to the running executable) when "code mode" is enabled. Shipped as its
   # own release asset, so the native build must fetch and install it too.
   codeModeHostHashes = {
-    "aarch64-apple-darwin" = "0im248hb4vb7wd0k4fkg87chszsac022ijy7d49m9zmy60j2iybc";
-    "x86_64-apple-darwin" = "07rdypzbqvmq9z6mx6q61jf00n4f6xyp3nj7s2f0vy9pjwfv5lkg";
-    "x86_64-unknown-linux-musl" = "0gcr30mf1mgfwqfpiqhmvjb0qyq23vwgfgjii7s2nz4lb9fcdn96";
-    "aarch64-unknown-linux-musl" = "0sniqrhxcff3rghai6nsx59fm5zil4i56hk7wiqkmhhsysamdcia";
+    "aarch64-apple-darwin" = "15181psvm7w24kiymnjn0im6h0xbh9hz48a7shyr3pplvk5a3b80";
+    "x86_64-apple-darwin" = "15zxzfm180jryl76y9976np0865wmxjvqg2rbn7n81l40mlh5zlc";
+    "x86_64-unknown-linux-musl" = "0pyj7lw3i0amgmfacngn0m7gcxbnsah7h74k82alda0npvqdv6hq";
+    "aarch64-unknown-linux-musl" = "1rsqq0scrkc9dsfbxlffyhvisykfqkiryhb3finc6idaz56n24h6";
   };
 
   nodeOptionalDepHashes = {

--- a/package.nix
+++ b/package.nix
@@ -42,6 +42,16 @@ let
     "aarch64-unknown-linux-musl" = "1f5mm1flbsjv62iqix3z8nd2kvp34d16lxfkpd6ysv74k1gyzy5r";
   };
 
+  # codex >= 0.143 spawns a separate `codex-code-mode-host` binary (found
+  # next to the main executable) when "code mode" is enabled. Shipped as its
+  # own release asset, so the native build must fetch and install it too.
+  codeModeHostHashes = {
+    "aarch64-apple-darwin" = "0im248hb4vb7wd0k4fkg87chszsac022ijy7d49m9zmy60j2iybc";
+    "x86_64-apple-darwin" = "07rdypzbqvmq9z6mx6q61jf00n4f6xyp3nj7s2f0vy9pjwfv5lkg";
+    "x86_64-unknown-linux-musl" = "0gcr30mf1mgfwqfpiqhmvjb0qyq23vwgfgjii7s2nz4lb9fcdn96";
+    "aarch64-unknown-linux-musl" = "0sniqrhxcff3rghai6nsx59fm5zil4i56hk7wiqkmhhsysamdcia";
+  };
+
   nodeOptionalDepHashes = {
     "darwin-arm64" = "061frx0hmszjka6wq2w75bw29f6zc82bpnniipavlrhg2y2mcnin";
     "darwin-x64" = "1q1jc5za9wi66xlji97zabcfd098q4fbhxx3b5apkgil334hirq3";
@@ -55,6 +65,13 @@ let
     fetchurl {
       url = nativeBinaryUrl;
       sha256 = nativeHashes.${platform};
+    }
+  else null;
+
+  codeModeHost = if runtime == "native" && platform != null then
+    fetchurl {
+      url = "https://github.com/openai/codex/releases/download/rust-v${version}/codex-code-mode-host-${platform}.tar.gz";
+      sha256 = codeModeHostHashes.${platform};
     }
   else null;
 
@@ -112,6 +129,10 @@ stdenv.mkDerivation rec {
     mv build/codex-${platform} build/codex
     chmod u+w,+x build/codex
 
+    tar -xzf ${codeModeHost} -C build
+    mv build/codex-code-mode-host-${platform} build/codex-code-mode-host
+    chmod u+w,+x build/codex-code-mode-host
+
     runHook postBuild
   '' else ''
     runHook preBuild
@@ -139,6 +160,8 @@ stdenv.mkDerivation rec {
 
     cp build/codex $out/bin/codex-raw
     chmod +x $out/bin/codex-raw
+    cp build/codex-code-mode-host $out/bin/codex-code-mode-host
+    chmod +x $out/bin/codex-code-mode-host
     makeWrapper "$out/bin/codex-raw" "$out/bin/${selected.binName}" \
       --run 'export CODEX_EXECUTABLE_PATH="$HOME/.local/bin/${selected.binName}"' \
       --set DISABLE_AUTOUPDATER 1 \

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -42,6 +42,16 @@ fetch_native_hash() {
     echo "$hash" | tr -d '\n'
 }
 
+fetch_code_mode_host_hash() {
+    local version="$1"
+    local platform="$2"
+    local url="${GITHUB_RELEASE_BASE}/rust-v${version}/codex-code-mode-host-${platform}.tar.gz"
+
+    local hash
+    hash=$(nix-prefetch-url "$url" 2>/dev/null | tail -1)
+    echo "$hash" | tr -d '\n'
+}
+
 fetch_npm_hash() {
     local version="$1"
     local url="${NPM_REGISTRY_URL}/${NPM_PACKAGE_NAME}/-/codex-${version}.tgz"
@@ -101,6 +111,23 @@ update_native_hash() {
     mv "$temp_file" package.nix
 }
 
+update_code_mode_host_hash() {
+    local platform="$1"
+    local hash="$2"
+    local temp_file
+    temp_file=$(mktemp)
+
+    awk -v platform="$platform" -v hash="$hash" '
+        /codeModeHostHashes = \{/ { in_block=1 }
+        in_block && $0 ~ "\"" platform "\"" {
+            sub(/= "[^"]*"/, "= \"" hash "\"")
+        }
+        in_block && /\};/ { in_block=0 }
+        { print }
+    ' package.nix > "$temp_file"
+    mv "$temp_file" package.nix
+}
+
 update_node_optional_dep_hash() {
     local platform="$1"
     local hash="$2"
@@ -141,6 +168,20 @@ update_to_version() {
         fi
         log_info "  $platform: $native_hash"
         update_native_hash "$platform" "$native_hash"
+    done
+
+    log_info "Fetching code-mode host hashes..."
+    for platform in "${NATIVE_PLATFORMS[@]}"; do
+        log_info "  Fetching hash for $platform..."
+        local code_mode_host_hash
+        code_mode_host_hash=$(fetch_code_mode_host_hash "$new_version" "$platform")
+        if [ -z "$code_mode_host_hash" ]; then
+            log_error "Failed to fetch code-mode host hash for $platform"
+            mv package.nix.bak package.nix
+            exit 1
+        fi
+        log_info "  $platform: $code_mode_host_hash"
+        update_code_mode_host_hash "$platform" "$code_mode_host_hash"
     done
 
     log_info "Fetching npm tarball hash..."


### PR DESCRIPTION
(note from a human: hi! it looks like the new 5.6 models switched something such that they require using a new binary for tool usage, which is not provided by the flake here - so I had an agent modify the flake to do so. code was AI-generated but i'm using this on my machine and it un-broke codex for me.)

codex >= 0.143 spawns a separate `codex-code-mode-host` binary when "code mode" is enabled, resolving it next to the main executable (`dirname(current_exe)/codex-code-mode-host`). It's shipped as its own GitHub release asset, but the native build only fetches `codex` — so once the server enables code mode, every tool call fails with:

```
ERROR codex_core::tools::router: failed to spawn code-mode host
  <store>/bin/codex-code-mode-host: No such file or directory (os error 2)
```

Faking it with a symlink to `codex-raw` doesn't work: the host is a genuinely separate binary, and a symlink resolves back through `/proc/self/exe`, so it falls through to the CLI and the parent reports "code-mode host exited during handshake".

This fetches the matching `codex-code-mode-host-<platform>.tar.gz` for all four native platforms and installs it beside `codex-raw`, where codex looks for it. `update.sh` now maintains its per-platform hashes alongside the existing ones.

Tested on `x86_64-linux`: `nix build .#codex`, then a code-mode `codex exec` runs cleanly through the host with no spawn/handshake errors (previously ENOENT). Node runtime is unchanged (the npm package already bundles the host).

Diagnosed and implemented with Claude Code.


## Maintainer update

- Rebased onto current `main` (Codex 0.144.1) while preserving Avi as author of the original commits.
- Refreshed all four code-mode host hashes from the official 0.144.1 release asset SHA-256 digests.
- Added a CI assertion that the native output contains an executable `codex-code-mode-host`.
- Updated the package documentation for the required companion executable and release artifact hashes.
- Verified `nix build .#codex`, an offline helper launch with closed stdin, `nix build .#codex-node`, and `nix flake check`.
- Cross-checked the package layout and fallback behavior against the [official Codex 0.144.1 changelog](https://developers.openai.com/codex/changelog/) and tagged upstream source.

Closes #121