### PR TITLE
fix: preserve native process name

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -48,6 +48,9 @@ jobs:
         run: |
           test -f ./result/bin/codex
           test -x ./result/bin/codex-code-mode-host
+          test -x ./result/libexec/codex
+          test -x ./result/libexec/codex-code-mode-host
+          test -L ./result/bin/codex-code-mode-host
 
       - name: Run basic functionality test
         run: |

--- a/package.nix
+++ b/package.nix
@@ -163,13 +163,16 @@ stdenv.mkDerivation rec {
 
   installPhase = if runtime == "native" then ''
     runHook preInstall
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/libexec
 
-    cp build/codex $out/bin/codex-raw
-    chmod +x $out/bin/codex-raw
-    cp build/codex-code-mode-host $out/bin/codex-code-mode-host
-    chmod +x $out/bin/codex-code-mode-host
-    makeWrapper "$out/bin/codex-raw" "$out/bin/${selected.binName}" \
+    # Keep the wrapped executable's basename canonical for process discovery.
+    # The code-mode host must remain next to the executable Codex actually runs.
+    cp build/codex "$out/libexec/${selected.binName}"
+    chmod +x "$out/libexec/${selected.binName}"
+    cp build/codex-code-mode-host $out/libexec/codex-code-mode-host
+    chmod +x $out/libexec/codex-code-mode-host
+    ln -s ../libexec/codex-code-mode-host $out/bin/codex-code-mode-host
+    makeWrapper "$out/libexec/${selected.binName}" "$out/bin/${selected.binName}" \
       --run 'export CODEX_EXECUTABLE_PATH="$HOME/.local/bin/${selected.binName}"' \
       --set DISABLE_AUTOUPDATER 1 \
       ${lib.optionalString stdenv.isLinux ''--prefix PATH : "${linuxRuntimePath}"''}


### PR DESCRIPTION
## Summary

- install the native Codex executable under `libexec/codex` instead of `bin/codex-raw`
- keep `codex-code-mode-host` adjacent to the executable and expose the existing `bin` path through a symlink
- verify the native layout in the PR workflow

This preserves the observable `codex` process name after the wrapper execs the native binary, which allows process-based discovery and integrations to recognize Codex reliably.

## Validation

- `nix build .#codex --print-build-logs`
- `nix flake check --print-build-logs`
- `./result/bin/codex --version`
- live `codex app-server` check: `/proc/<pid>/comm` is `codex` and `/proc/<pid>/exe` resolves to `libexec/codex`